### PR TITLE
Accept report lines ended with CRLF (Windows) Interrupt processing of report immediately on the first error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,9 +156,9 @@ pub fn run_dedupe(op: DedupeOp, config: DedupeConfig, log: &mut Log) -> Result<(
                 None
             }
         })
+        .take_while(|g| g.is_some())
+        .map(|g| g.unwrap())
         .inspect(|_| progress.tick())
-        .fuse()
-        .flatten()
         .par_bridge();
 
     let script = dedupe(groups, op, &dedupe_config, log);


### PR DESCRIPTION
If the report contained CRLF sequence after the group header line,
an attempt to run `fclones remove` or `fclones link`
resulted in the following error:

    Failed to read file list: Malformed group header: <path>

Fixes #58