### PR TITLE
Implement `fclones move` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As a result, FClones easily outperforms many other popular duplicate finders by 
   - filtering by min/max file size
   - proper handling of symlinks and hardlinks
 * Removing redundant files
-  - removing or replacing files with soft or hard links
+  - removing, moving or replacing files with soft or hard links
   - selecting files for removal by path or name patterns  
   - prioritizing files to remove by creation, modification, last access time or nesting level
 * High performance
@@ -184,17 +184,20 @@ Exclude a part of the directory tree from the scan:
     fclones group / --exclude '/dev/**' '/proc/**'    
 
 ### Removing Files
-To remove files or replace them by links, you need to send the report produced by
-`fclones group` to the standard input of `fclones remove` or `fclones link` command.
+To remove duplicate files, move them to a different place or replace them by links, 
+you need to send the report produced by `fclones group` to the standard input 
+of `fclones remove`, `fclones move` or `fclones link` command.
 The report format is detected automatically. Currently, `default` and `json` report 
 formats are supported. 
 
 Assuming the list of duplicates has been saved in file `dupes.txt`, the following commands would remove
 the redundant files: 
 
-    fclones link <dupes.txt         # replace with hard links
-    fclones link -s <dupes.txt      # replace with soft links
-    fclones remove <dupes.txt       # remove totally
+    fclones link <dupes.txt             # replace with hard links
+    fclones link -s <dupes.txt          # replace with soft links
+    fclones move target_dir <dupes.txt  # move to target_dir  
+    fclones remove <dupes.txt           # remove totally
+    
 
 If you prefer to do everything at once without storing the list of groups in a file, you can pipe:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -510,6 +510,19 @@ pub enum Command {
     /// The list of groups earlier produced by `fclones group` should be submitted
     /// on the standard input. Only the default text format is supported.
     Remove(DedupeConfig),
+
+    /// Moves redundant files to the given directory.
+    ///
+    /// The list of groups earlier produced by `fclones group` should be submitted
+    /// on the standard input. Only the default text format is supported.
+    Move {
+        #[structopt(flatten)]
+        config: DedupeConfig,
+
+        /// Target directory where the redundant files should be moved to.
+        #[structopt(parse(from_os_str))]
+        target: PathBuf,
+    },
 }
 
 /// Finds and cleans up redundant files

--- a/src/device.rs
+++ b/src/device.rs
@@ -254,6 +254,15 @@ impl DiskDevices {
         result
     }
 
+    /// Returns the mount point holding given path
+    pub fn get_mount_point(&self, path: &Path) -> &Path {
+        self.mount_points
+            .iter()
+            .map(|(p, _)| p)
+            .find(|p| p.is_prefix_of(path))
+            .unwrap_or(&self.mount_points[0].0)
+    }
+
     /// Returns the disk device which holds the given path
     pub fn get_by_path(&self, path: &Path) -> &DiskDevice {
         self.mount_points

--- a/src/path.rs
+++ b/src/path.rs
@@ -84,6 +84,17 @@ impl Path {
         result
     }
 
+    /// If `path` is relative, works the same as [`join`].
+    /// If `path` is absolute, ignores `self` and returns `path`.
+    pub fn resolve<P: AsRef<Path>>(self: &Arc<Path>, path: P) -> Path {
+        let path = path.as_ref();
+        if path.is_relative() {
+            self.join(path)
+        } else {
+            path.clone()
+        }
+    }
+
     /// Returns the name of the last component of this path or None
     /// if the path is directory (e.g. root dir or parent dir).
     pub fn file_name(&self) -> Option<OsString> {
@@ -127,6 +138,17 @@ impl Path {
             base_components.next();
         }
         Some(Path::make(self_components))
+    }
+
+    /// If this path is absolute, strips the root component and returns a relative path.
+    /// Otherwise returns a clone of this path.
+    /// E.g. `/foo/bar` becomes `foo/bar`
+    pub fn strip_root(&self) -> Path {
+        if self.is_absolute() {
+            Path::make(self.components().into_iter().skip(1))
+        } else {
+            self.clone()
+        }
     }
 
     /// Returns true if self is a prefix of another path


### PR DESCRIPTION
The move command moves duplicate files to a
different directory. If files reside on the same
file system (mount point), rename command is used.
If files reside on different file systems, the file
is copied and the original is removed.
The directory structure is preserved.

The new syntax:

    fclones move <target_dir>