### PR TITLE
Remove libudev dependency from CI and build processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           name: Setup build environment
           command: |
             sudo apt-get update
-            sudo apt-get install -y git libudev1 libudev-dev
+            sudo apt-get install -y git
           no_output_timeout: 1800s
       - run:
           name: Calculate dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:latest
 RUN apt-get update
-RUN apt-get install -y libudev-dev fakeroot alien gcc-mingw-w64-x86-64 zip
+RUN apt-get install -y fakeroot alien gcc-mingw-w64-x86-64 zip
 RUN rustup component add rustfmt
 RUN rustup component add clippy
 RUN rustup toolchain install stable-x86_64-pc-windows-gnu


### PR DESCRIPTION
Commit 09e2c7790db6 removed the dependency on `libudev-sys` which means fclones no longer needs libudev installed on the host.
