### PR TITLE
Make group output deterministic with existing hardlinks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -476,6 +476,12 @@ where
                     .unique_by(|p| p.path.hash128()),
             )
         } else {
+            // The BTreeMap inside GroupMap results in a random ordering, so repeated runs
+            // will list a different representative filename first for a given inode.
+            // By ordering these the output becomes deterministic.
+            let mut file_group = file_group;
+            file_group.sort_by(|f1, f2| f1.path.cmp(&f2.path));
+
             files.extend(
                 file_group
                     .into_iter()


### PR DESCRIPTION
The non-determinism can be observed as follows:

`mkdir d; echo foo > d/1; cp d/1 d/2; ln d/1 d/3` and then `fclones group d`:

Which of the two hardlinked files is chosen is random because the ordering inside the `BTreeMap` changes (on purpose).

Sorting the file group fixes that.