### PR TITLE
Fix handling of non-unicode and control chars in paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,8 +372,9 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "shell-words",
+ "serde_test",
  "smallvec",
+ "stfu8",
  "structopt",
  "sysinfo",
  "tempfile",
@@ -909,10 +910,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.0.0"
+name = "serde_test"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
+checksum = "21675ba6f9d97711cc00eee79d8dd7d0a31e571c350fb4d8a7c78f70c0e7b0e9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -925,6 +929,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stfu8"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "019f0c664fd85d5a87dcfb62b40b691055392a35a6e59f4df83d4b770db7e876"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ reflink = "0.1.3"
 regex = "1.4.5"
 serde_json = "1.0"
 serde = { version = "1", features = ["derive"] }
-shell-words = "1.0.0"
 smallvec = "1.6.1"
+stfu8 = "0.2"
 structopt = "0.3.21"
 sysinfo = "0.15.0"
 thread_local = "1.0.1"
@@ -65,6 +65,7 @@ winapi = "0.3.8"
 winapi-util = "0.1.5"
 
 [dev-dependencies]
+serde_test = "1.0"
 tempfile = "3.2.0"
 
 [profile.release]

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -1,0 +1,460 @@
+//! Command line argument parsing and quoting utilities.
+//!
+//! Provides lossless OsString conversions to and from String by shell-like escaping and quoting.
+
+use std::error::Error;
+use std::ffi::{OsStr, OsString};
+use std::fmt::{Debug, Display, Formatter};
+use std::mem;
+
+use itertools::Itertools;
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use stfu8::DecodeError;
+
+/// Argument passed to the app
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct Arg(OsString);
+
+impl Arg {
+    pub fn from_escaped_string(s: &str) -> Result<Self, DecodeError> {
+        Ok(Arg(from_stfu8(s)?))
+    }
+
+    pub fn to_escaped_string(&self) -> String {
+        to_stfu8(self.0.clone())
+    }
+
+    pub fn quote(&self) -> String {
+        quote(self.0.to_os_string())
+    }
+
+    pub fn as_os_str(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<OsStr> for Arg {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_os_str()
+    }
+}
+
+impl From<OsString> for Arg {
+    fn from(s: OsString) -> Self {
+        Arg(s)
+    }
+}
+
+impl From<&OsStr> for Arg {
+    fn from(s: &OsStr) -> Self {
+        Arg(OsString::from(s))
+    }
+}
+
+impl From<&str> for Arg {
+    fn from(s: &str) -> Self {
+        Arg(OsString::from(s))
+    }
+}
+
+struct ArgVisitor;
+
+impl Visitor<'_> for ArgVisitor {
+    type Value = Arg;
+
+    fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an STFU encoded string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        let arg = Arg::from_escaped_string(v).map_err(|e| E::custom(e.to_string()))?;
+        Ok(arg)
+    }
+}
+
+impl Serialize for Arg {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.to_escaped_string().as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Arg {
+    fn deserialize<D>(deserializer: D) -> Result<Arg, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ArgVisitor)
+    }
+}
+
+/// Returns a lossless string representation in [STFU8 format](https://crates.io/crates/stfu8).
+#[cfg(unix)]
+pub fn to_stfu8(s: OsString) -> String {
+    use std::os::unix::ffi::OsStringExt;
+    let raw_path_bytes = s.into_vec();
+    stfu8::encode_u8(&raw_path_bytes)
+}
+
+/// Returns a lossless string representation in [STFU8 format](https://crates.io/crates/stfu8).
+#[cfg(windows)]
+pub fn to_stfu8(s: OsString) -> String {
+    use std::os::windows::ffi::OsStrExt;
+    let raw_path_bytes: Vec<u16> = s.encode_wide().collect();
+    stfu8::encode_u16(&raw_path_bytes)
+}
+
+/// Decodes the path from the string encoded with [`to_stfu8`](OsString::to_stfu8).
+#[cfg(unix)]
+pub fn from_stfu8(encoded: &str) -> Result<OsString, DecodeError> {
+    use std::os::unix::ffi::OsStringExt;
+    let raw_bytes = stfu8::decode_u8(encoded)?;
+    Ok(OsString::from_vec(raw_bytes))
+}
+
+/// Decodes the path from the string encoded with [`to_stfu8`](OsString::to_stfu8).
+#[cfg(windows)]
+pub fn from_stfu8(encoded: &str) -> Result<OsString, DecodeError> {
+    use std::os::windows::ffi::OsStringExt;
+    let raw_bytes = stfu8::decode_u16(encoded)?;
+    Ok(OsString::from_wide(&raw_bytes))
+}
+
+const SPECIAL_CHARS: [char; 25] = [
+    '|', '&', ';', '<', '>', '(', ')', '{', '}', '$', '`', '\\', '\'', '"', ' ', '\t', '*', '?',
+    '+', '[', ']', '#', '˜', '=', '%',
+];
+
+/// Escapes special characters in a string, so that it will retain its literal meaning when used as
+/// a part of command in Unix shell.
+///
+/// It tries to avoid introducing any unnecessary quotes or escape characters, but specifics
+/// regarding quoting style are left unspecified.
+pub fn quote(s: OsString) -> String {
+    let lossy = s.to_string_lossy();
+    if lossy
+        .chars()
+        .any(|c| c < '\u{20}' || c == '\u{7f}' || c == '\u{fffd}')
+    {
+        format!("$'{}'", to_stfu8(s))
+    } else if lossy.chars().any(|c| SPECIAL_CHARS.contains(&c)) {
+        format!("'{}'", lossy.replace('\'', "\\'"))
+    } else {
+        lossy.to_string()
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseError {
+    pub msg: String,
+}
+
+impl ParseError {
+    pub fn new(msg: &str) -> ParseError {
+        ParseError {
+            msg: msg.to_string(),
+        }
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl Error for ParseError {}
+
+enum State {
+    /// Within a delimiter.
+    Delimiter,
+    /// After backslash, but before starting word.
+    Backslash,
+    /// Within an unquoted word.
+    Unquoted,
+    /// After backslash in an unquoted word.
+    UnquotedBackslash,
+    /// Within a single quoted word.
+    SingleQuoted,
+    /// Within a double quoted word.
+    DoubleQuoted,
+    /// After backslash inside a double quoted word.
+    DoubleQuotedBackslash,
+    /// After dollar in an unquoted word.
+    Dollar,
+    /// Within a quoted word preceded by a dollar sign.
+    DollarQuoted,
+    /// After backslash in a dollar-quoted word.
+    DollarQuotedBackslash,
+    /// Inside a comment.
+    Comment,
+}
+
+/// Appends a character to OsString
+fn append(s: &mut OsString, c: char) {
+    let mut buf = [0; 4];
+    let c = c.encode_utf8(&mut buf);
+    s.push(c)
+}
+
+/// Splits command line into separate arguments, in much the same way Unix shell would, but without
+/// many of expansion the shell would perform.
+///
+/// The split functionality is compatible with behaviour of Unix shell, but with word expansions
+/// limited to quote removal, and without special token recognition rules for operators.
+///
+/// The result is exactly the same as one obtained from Unix shell as long as those unsupported
+/// features are not present in input: no operators, no variable assignments, no tilde expansion,
+/// no parameter expansion, no command substitution, no arithmetic expansion, no pathname
+/// expansion.
+///
+/// In case those unsupported shell features are present, the syntax that introduce them is
+/// interpreted literally.
+///
+/// # Errors
+///
+/// When input contains unmatched quote, an error is returned.
+///
+/// # Compatibility with other implementations
+///
+/// It should be fully compatible with g_shell_parse_argv from GLib, except that in GLib
+/// it is an error not to have any words after tokenization.
+///
+/// It is also very close to shlex.split available in Python standard library, when used in POSIX
+/// mode with support for comments. Though, shlex implementation diverges from POSIX, and from
+/// implementation contained herein in three aspects. First, it doesn't support line continuations.
+/// Second, inside double quotes, the backslash characters retains its special meaning as an escape
+/// character only when followed by \\ or \", whereas POSIX specifies that it should retain its
+/// special meaning when followed by: $, \`, \", \\, or a newline. Third, it treats carriage return
+/// as one of delimiters.
+/// ```
+pub fn split(s: &str) -> Result<Vec<Arg>, ParseError> {
+    // Based on shell-words crate by Tomasz Miąsko
+    // Handling of dollar quotes added by Piotr Kołaczkowski
+
+    use State::*;
+
+    let mut words = Vec::new();
+    let mut word = OsString::new();
+
+    let mut pos = 0;
+    let mut dollar_quote_start = 0;
+
+    let mut chars = s.chars();
+    let mut state = Delimiter;
+
+    loop {
+        let c = chars.next();
+        state = match state {
+            Delimiter => match c {
+                None => break,
+                Some('\'') => SingleQuoted,
+                Some('\"') => DoubleQuoted,
+                Some('\\') => Backslash,
+                Some('\t') | Some(' ') | Some('\n') => Delimiter,
+                Some('$') => Dollar,
+                Some('#') => Comment,
+                Some(c) => {
+                    append(&mut word, c);
+                    Unquoted
+                }
+            },
+            Backslash => match c {
+                None => {
+                    append(&mut word, '\\');
+                    words.push(Arg(mem::replace(&mut word, OsString::new())));
+                    break;
+                }
+                Some('\n') => Delimiter,
+                Some(c) => {
+                    append(&mut word, c);
+                    Unquoted
+                }
+            },
+            Unquoted => match c {
+                None => {
+                    words.push(Arg(mem::replace(&mut word, OsString::new())));
+                    break;
+                }
+                Some('\'') => SingleQuoted,
+                Some('\"') => DoubleQuoted,
+                Some('\\') => UnquotedBackslash,
+                Some('$') => Dollar,
+                Some('\t') | Some(' ') | Some('\n') => {
+                    words.push(Arg(mem::replace(&mut word, OsString::new())));
+                    Delimiter
+                }
+                Some(c) => {
+                    append(&mut word, c);
+                    Unquoted
+                }
+            },
+            UnquotedBackslash => match c {
+                None => {
+                    append(&mut word, '\\');
+                    words.push(Arg(mem::replace(&mut word, OsString::new())));
+                    break;
+                }
+                Some('\n') => Unquoted,
+                Some(c) => {
+                    append(&mut word, c);
+                    Unquoted
+                }
+            },
+            SingleQuoted => match c {
+                None => return Err(ParseError::new("Unclosed single quote")),
+                Some('\'') => Unquoted,
+                Some(c) => {
+                    append(&mut word, c);
+                    SingleQuoted
+                }
+            },
+            DoubleQuoted => match c {
+                None => return Err(ParseError::new("Unclosed double quote")),
+                Some('\"') => Unquoted,
+                Some('\\') => DoubleQuotedBackslash,
+                Some(c) => {
+                    append(&mut word, c);
+                    DoubleQuoted
+                }
+            },
+            DoubleQuotedBackslash => match c {
+                None => return Err(ParseError::new("Unexpected end of input")),
+                Some('\n') => DoubleQuoted,
+                Some(c @ '$') | Some(c @ '`') | Some(c @ '"') | Some(c @ '\\') => {
+                    append(&mut word, c);
+                    DoubleQuoted
+                }
+                Some(c) => {
+                    append(&mut word, '\\');
+                    append(&mut word, c);
+                    DoubleQuoted
+                }
+            },
+            Dollar => match c {
+                None => return Err(ParseError::new("Unexpected end of input")),
+                Some('\'') => {
+                    dollar_quote_start = pos + 1;
+                    DollarQuoted
+                }
+                Some(_) => return Err(ParseError::new("Expected single quote")),
+            },
+            DollarQuoted => match c {
+                None => return Err(ParseError::new("Unclosed single quote")),
+                Some('\\') => DollarQuotedBackslash,
+                Some('\'') => {
+                    let quoted_slice = &s[dollar_quote_start..pos];
+                    let decoded = from_stfu8(quoted_slice).map_err(|e| {
+                        ParseError::new(format!("Failed to decode STFU-8 chunk: {}", e).as_str())
+                    })?;
+                    word.push(decoded.as_os_str());
+                    Unquoted
+                }
+                Some(_) => DollarQuoted,
+            },
+            DollarQuotedBackslash => match c {
+                None => return Err(ParseError::new("Unexpected end of input")),
+                Some(_) => DollarQuoted,
+            },
+            Comment => match c {
+                None => break,
+                Some('\n') => Delimiter,
+                Some(_) => Comment,
+            },
+        };
+        pos += 1;
+    }
+
+    Ok(words)
+}
+
+/// Joins multiple command line args into a single-line escaped representation
+pub fn join(args: &[Arg]) -> String {
+    args.iter().map(|arg| arg.quote()).join(" ")
+}
+
+#[cfg(test)]
+mod test {
+    use std::ffi::OsString;
+
+    use crate::arg::{quote, split, Arg};
+
+    #[test]
+    fn quote_no_special_chars() {
+        assert_eq!(quote(OsString::from("abc/def_123.txt")), "abc/def_123.txt");
+    }
+
+    #[test]
+    fn quote_path_with_control_chars() {
+        assert_eq!(quote(OsString::from("a\nb")), "$'a\\nb'");
+        assert_eq!(quote(OsString::from("a\tb")), "$'a\\tb'");
+    }
+
+    #[test]
+    fn quote_path_with_special_chars() {
+        assert_eq!(quote(OsString::from("a b")), "'a b'");
+        assert_eq!(quote(OsString::from("a*b")), "'a*b'");
+        assert_eq!(quote(OsString::from("a?b")), "'a?b'");
+        assert_eq!(quote(OsString::from("$ab")), "'$ab'");
+        assert_eq!(quote(OsString::from("a(b)")), "'a(b)'");
+        assert_eq!(quote(OsString::from("a\\b")), "'a\\b'");
+    }
+
+    #[test]
+    fn split_unquoted_args() {
+        assert_eq!(
+            split("arg1 arg2").unwrap(),
+            vec![Arg::from("arg1"), Arg::from("arg2")]
+        )
+    }
+
+    #[test]
+    fn split_single_quoted_args() {
+        assert_eq!(
+            split("'arg1 with spaces' arg2").unwrap(),
+            vec![Arg::from("arg1 with spaces"), Arg::from("arg2")]
+        )
+    }
+
+    #[test]
+    fn split_doubly_quoted_args() {
+        assert_eq!(
+            split("\"arg1 with spaces\" arg2").unwrap(),
+            vec![Arg::from("arg1 with spaces"), Arg::from("arg2")]
+        )
+    }
+
+    #[test]
+    fn split_quotes_escaping() {
+        assert_eq!(
+            split("\"escaped \\\" quotes\"").unwrap(),
+            vec![Arg::from("escaped \" quotes")]
+        )
+    }
+
+    #[test]
+    fn split_spaces_escaping() {
+        assert_eq!(
+            split("escaped\\ space").unwrap(),
+            vec![Arg::from("escaped space")]
+        )
+    }
+
+    #[test]
+    fn dollar_quoting() {
+        assert_eq!(
+            split("arg1 $'arg2-\\n\\t\\\\' arg3-$'\\x7f'").unwrap(),
+            vec![
+                Arg::from("arg1"),
+                Arg::from("arg2-\n\t\\"),
+                Arg::from("arg3-\x7f")
+            ]
+        )
+    }
+}

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -62,14 +62,17 @@ impl FileLock {
             .create(false)
             .open(&path_buf)
             .map_err(|e| {
-                io::Error::new(e.kind(), format!("Failed to open file {}: {}", path, e))
+                io::Error::new(
+                    e.kind(),
+                    format!("Failed to open file {}: {}", path.display(), e),
+                )
             })?;
 
         #[cfg(unix)]
         if let Err(e) = Self::fcntl_lock(&file) {
             return Err(io::Error::new(
                 e.kind(),
-                format!("Failed to lock file {}: {}", path, e),
+                format!("Failed to lock file {}: {}", path.display(), e),
             ));
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,18 +2,17 @@ use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{stdin, Write};
-use std::path::PathBuf;
 use std::process::exit;
 use std::sync::Arc;
 use std::{fs, io};
 
+use console::style;
 use fallible_iterator::FallibleIterator;
 use itertools::Itertools;
 use rayon::iter::ParallelBridge;
 use regex::Regex;
 use structopt::StructOpt;
 
-use console::style;
 use fclones::config::{Command, Config, DedupeConfig, GroupConfig, Parallelism};
 use fclones::log::Log;
 use fclones::report::{open_report, ReportHeader};
@@ -148,7 +147,7 @@ fn get_command_config(header: &ReportHeader) -> Result<Config, Error> {
     // Configure the same base directory as set when running the previous command.
     // This is important to get the correct input paths.
     if let Command::Group(ref mut group_config) = command.command {
-        group_config.base_dir = PathBuf::from(&header.base_dir)
+        group_config.base_dir = header.base_dir.to_path_buf();
     }
     Ok(command)
 }

--- a/src/reflink.rs
+++ b/src/reflink.rs
@@ -44,7 +44,11 @@ pub fn reflink(src: &FileMetadata, dest: &FileMetadata, log: &Log) -> io::Result
             let result = metadata
                 .and_then(|metadata| restore_some_metadata(&parent.to_path_buf(), &metadata));
             if let Err(e) = result {
-                log.warn(format!("Failed keep metadata for {}: {}", parent, e))
+                log.warn(format!(
+                    "Failed keep metadata for {}: {}",
+                    parent.display(),
+                    e
+                ))
             }
         }
     }
@@ -70,7 +74,11 @@ fn linux_reflink(src: &FileMetadata, dest: &FileMetadata, log: &Log) -> io::Resu
 
     let remove_temporary = |temporary| {
         if let Err(e) = FsCommand::remove(&temporary) {
-            log.warn(format!("Failed to remove temporary {}: {}", &temporary, e))
+            log.warn(format!(
+                "Failed to remove temporary {}: {}",
+                temporary.display(),
+                e
+            ))
         }
     };
 
@@ -85,7 +93,9 @@ fn linux_reflink(src: &FileMetadata, dest: &FileMetadata, log: &Log) -> io::Resu
             if let Err(remove_err) = FsCommand::unsafe_rename(&tmp, &dest.path) {
                 log.warn(format!(
                     "Failed to undo deduplication from {} to {}: {}",
-                    &dest, &tmp, remove_err
+                    &dest,
+                    tmp.display(),
+                    remove_err
                 ))
             }
             Err(e)
@@ -159,7 +169,12 @@ fn copy_by_reflink(src: &FcPath, dest: &FcPath) -> io::Result<()> {
     reflink::reflink(&src.to_path_buf(), &dest.to_path_buf()).map_err(|e| {
         io::Error::new(
             e.kind(),
-            format!("Failed to deduplicate {} -> {}: {}", dest, src, e),
+            format!(
+                "Failed to deduplicate {} -> {}: {}",
+                dest.display(),
+                src.display(),
+                e
+            ),
         )
     })
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -214,7 +214,7 @@ impl Transform {
             Ok(result) if !result.status.success() => {
                 log.err(format!(
                     "Failed to transform {}: {} returned non-zero status code: {}{}",
-                    input,
+                    input.display(),
                     self.program,
                     result.status.code().unwrap(),
                     Self::format_output_stream(result.stderr.as_str(), "STDERR")

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -116,7 +116,7 @@ impl<'a> Walk<'a> {
                 match fs::metadata(&p.to_path_buf()) {
                     Ok(metadata) if metadata.is_dir() && self.depth == 0 => self.log_warn(format!(
                         "Skipping directory {} because recursive scan is disabled.",
-                        p
+                        p.display()
                     )),
                     _ => scope.spawn(|scope| self.visit_path(p, scope, 0, &state)),
                 }


### PR DESCRIPTION
Paths stored in reports are now in STFU-8 format,
which escapes non-UTF8, special and control characters,
so that text files produced by fclones are always valid UTF-8.
Additionally, newlines won't mess up the report file format.

A side effect of this change is that on Windows, the backslash
character ('\') used as a directory delimiter is
encoded as a double backslash '\\'.

Fixes #102