### PR TITLE
Only use the reflink crate on Linux for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ nom = { version = "5.1", features = ["regexp"] }
 num_cpus = "1.13"
 rand = "0.8"
 rayon = "1.5"
-reflink = "0.1"
 regex = "1.5"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -64,7 +63,11 @@ libc = "0.2"
 winapi = "0.3"
 winapi-util = "0.1"
 
+[target.'cfg(not(any(target_os = "linux", target_os = "android")))'.dependencies]
+reflink = "0.1"
+
 [dev-dependencies]
+reflink = "0.1"
 serde_test = "1.0"
 tempfile = "3.3"
 

--- a/src/reflink.rs
+++ b/src/reflink.rs
@@ -7,7 +7,6 @@ use filetime::FileTime;
 use crate::dedupe::{FileMetadata, FsCommand};
 use crate::lock::FileLock;
 use crate::log::Log;
-use crate::Path as FcPath;
 
 /// Calls OS-specific reflink implementations with an option to call the more generic
 /// one during testing one on Linux ("crosstesting").
@@ -165,7 +164,8 @@ fn restore_some_metadata(path: &std::path::Path, metadata: &Metadata) -> io::Res
 }
 
 // Reflink which expects the destination to not exist.
-fn copy_by_reflink(src: &FcPath, dest: &FcPath) -> io::Result<()> {
+#[cfg(any(not(any(target_os = "linux", target_os = "android")), test))]
+fn copy_by_reflink(src: &crate::Path, dest: &crate::Path) -> io::Result<()> {
     reflink::reflink(&src.to_path_buf(), &dest.to_path_buf()).map_err(|e| {
         io::Error::new(
             e.kind(),
@@ -180,9 +180,16 @@ fn copy_by_reflink(src: &FcPath, dest: &FcPath) -> io::Result<()> {
 }
 
 // Create a reflink by removing the file and making a reflink copy of the original.
+#[cfg(any(not(any(target_os = "linux", target_os = "android")), test))]
 fn safe_reflink(src: &FileMetadata, dest: &FileMetadata, log: &Log) -> io::Result<()> {
     FsCommand::safe_remove(&dest.path, |link| copy_by_reflink(&src.path, link), log)?;
     Ok(())
+}
+
+// Dummy function so non-test cfg compiles
+#[cfg(not(any(not(any(target_os = "linux", target_os = "android")), test)))]
+fn safe_reflink(_src: &FileMetadata, _dest: &FileMetadata, _log: &Log) -> io::Result<()> {
+    unreachable!()
 }
 
 #[cfg(not(test))]
@@ -235,6 +242,7 @@ pub mod test {
     use crate::util::test::{cached_reflink_supported, read_file, with_dir, write_file};
 
     use super::*;
+    use crate::Path as FcPath;
 
     // Usually /dev/shm only exists on Linux.
     #[cfg(any(target_os = "linux"))]


### PR DESCRIPTION
Version 0.1.3 of the reflink crate does not compile with the musl libc.
However this lib is only used for "crosstesting" on Linux, the tool
itself already calls the ioctl for file cloning directly.

---

Fixes #95