### PR TITLE
workaround for sysinfo build failures on trueNAS freebsd 12 system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ sled = "0.34"
 smallvec = "1.8"
 stfu8 = "0.2"
 structopt = "0.3"
-sysinfo = "0.16"
+sysinfo = "0.23.10"
 thread_local = "1.1"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[0422/121950.949:ERROR:registration_protocol_win.cc(102)] CreateFile: The system cannot find the file specified. (0x2)

--- a/src/device.rs
+++ b/src/device.rs
@@ -96,7 +96,8 @@ impl DiskDevice {
         FileLen(match self.disk_type {
             DiskType::SSD => 4 * 1024,
             DiskType::HDD => 4 * 1024,
-            DiskType::Removable => 4 * 1024,
+            // Removable doesn't appear to be supported type in the latest sysinfo crate
+            // DiskType::Removable => 4 * 1024,
             DiskType::Unknown(_) => 4 * 1024,
         })
     }
@@ -105,7 +106,8 @@ impl DiskDevice {
         FileLen(match self.disk_type {
             DiskType::SSD => 4 * 1024,
             DiskType::HDD => 16 * 1024,
-            DiskType::Removable => 16 * 1024,
+            // Removable doesn't appear to be supported type in the latest sysinfo crate
+            // DiskType::Removable => 16 * 1024,
             DiskType::Unknown(_) => 16 * 1024,
         })
     }
@@ -118,7 +120,8 @@ impl DiskDevice {
         FileLen(match self.disk_type {
             DiskType::HDD => 64 * 1024 * 1024, // 64 MB
             DiskType::SSD => 64 * 1024,        // 64 kB
-            DiskType::Removable => 64 * 1024 * 1024,
+            // Removable doesn't appear to be supported type in the latest sysinfo crate
+            // DiskType::Removable => 64 * 1024 * 1024,
             DiskType::Unknown(_) => 64 * 1024 * 1024,
         })
     }
@@ -168,7 +171,8 @@ impl DiskDevices {
                 let p = match disk_type {
                     DiskType::SSD => pool_sizes.get(OsStr::new("ssd")),
                     DiskType::HDD => pool_sizes.get(OsStr::new("hdd")),
-                    DiskType::Removable => pool_sizes.get(OsStr::new("removable")),
+                    // Removable doesn't appear to be supported type in the latest sysinfo crate
+                    // DiskType::Removable => pool_sizes.get(OsStr::new("removable")),
                     DiskType::Unknown(_) => pool_sizes.get(OsStr::new("unknown")),
                 };
                 match p {
@@ -244,17 +248,17 @@ impl DiskDevices {
             String::from("unknown"),
             pool_sizes,
         );
-        for d in sys.get_disks() {
-            let device_name = Self::physical_device_name(d.get_name());
+        for d in sys.disks() {
+            let device_name = Self::physical_device_name(d.name());
             let index = result.add_device(
                 device_name,
-                d.get_type(),
-                String::from_utf8_lossy(d.get_file_system()).to_string(),
+                d.type_(),
+                String::from_utf8_lossy(d.file_system()).to_string(),
                 pool_sizes,
             );
             result
                 .mount_points
-                .push((Path::from(d.get_mount_point()), index));
+                .push((Path::from(d.mount_point()), index));
         }
         result
             .mount_points

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -157,8 +157,8 @@ fn evict_page_cache_if_low_mem(file: &mut File, len: FileLen) {
         if len > skipped_prefix_len {
             let mut system = System::new();
             system.refresh_memory();
-            let free_mem = system.get_free_memory();
-            let total_mem = system.get_total_memory();
+            let free_mem = system.free_memory();
+            let total_mem = system.total_memory();
             let free_ratio = free_mem as f32 / total_mem as f32;
             if free_ratio < 0.05 {
                 evict_page_cache(


### PR DESCRIPTION
I'm not sure how well this will work elsewhere, but it appears to have worked for me.