### PR TITLE
Respect .gitignore and .fdignore. Skip hidden files by default.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "fallible-iterator",
  "fiemap",
  "filetime",
+ "ignore",
  "indicatif",
  "indoc",
  "itertools",
@@ -394,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +431,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +459,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -944,6 +982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1252,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ dtparse = "1.2"
 dunce = "1.0"
 fallible-iterator = "0.2"
 filetime = "0.2"
+ignore = "0.4.18"
 indicatif = { version = "0.14", features = ["with_rayon"] }
 indoc = "1.0"
 itertools = "0.10"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ You can search in multiple directories:
 
     fclones group dir1 dir2 dir3
 
+By default, hidden files and files matching patterns listed in `.gitignore` and `.fdignore` are
+ignored. To search all files, use:
+
+    fclones group --no-ignore --hidden dir
+
 Limit the recursion depth:
     
     fclones group . --depth 1   # scan only files in the current dir, skip subdirs

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,11 +148,15 @@ pub struct GroupConfig {
     #[structopt(short = "d", long)]
     pub depth: Option<usize>,
 
-    /// Skips hidden files
-    #[structopt(short = "A", long)]
-    pub skip_hidden: bool,
+    /// Includes hidden files.
+    #[structopt(short = ".", long)]
+    pub hidden: bool,
 
-    /// Follows symbolic links
+    /// Does not respect .gitignore and .fdignore files.
+    #[structopt(short = "A", long)]
+    pub no_ignore: bool,
+
+    /// Follows symbolic links.
     #[structopt(short = "L", long)]
     pub follow_links: bool,
 
@@ -231,16 +235,16 @@ pub struct GroupConfig {
     #[structopt(long = "path", value_name("pattern"))]
     pub path_patterns: Vec<String>,
 
-    /// Excludes paths matched fully by any of the given patterns.
+    /// Ignores paths matched fully by any of the given patterns.
     #[structopt(long = "exclude", value_name("pattern"))]
     pub exclude_patterns: Vec<String>,
 
     /// Makes pattern matching case-insensitive.
     #[structopt(short = "i", long)]
-    pub caseless: bool,
+    pub ignore_case: bool,
 
     /// Expects patterns as Perl compatible regular expressions instead of Unix globs.
-    #[structopt(short = "g", long)]
+    #[structopt(short = "x", long)]
     pub regex: bool,
 
     /// Enables caching of file hashes.
@@ -317,7 +321,7 @@ impl GroupConfig {
     }
 
     fn compile_pattern(&self, s: &str) -> Result<Pattern, PatternError> {
-        let pattern_opts = if self.caseless {
+        let pattern_opts = if self.ignore_case {
             PatternOpts::case_insensitive()
         } else {
             PatternOpts::default()

--- a/src/group.rs
+++ b/src/group.rs
@@ -549,8 +549,9 @@ fn scan_files(ctx: &GroupCtx<'_>) -> Vec<Vec<FileInfo>> {
 
     let mut walk = Walk::new();
     walk.depth = config.depth.unwrap_or(usize::MAX);
-    walk.skip_hidden = config.skip_hidden;
+    walk.hidden = config.hidden;
     walk.follow_links = config.follow_links;
+    walk.no_ignore = config.no_ignore;
     walk.path_selector = ctx.path_selector.clone();
     walk.log = Some(ctx.log);
     walk.on_visit = spinner_tick;


### PR DESCRIPTION
Additionally, the options for controlling hidden files selection
have been changed. `--skip-hidden` has been removed, and replaced
with `--hidden` which has the opposite meaning. The short option
for including hidden files is `-.` as in ripgrep.
`-A` has been repurposed to mean `--no-ignore`
(A stands for "All files").

Fixes #101