### PR TITLE
Add an option to skip locking files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -590,6 +590,10 @@ pub struct DedupeConfig {
     /// `fclones group` command, if `--isolate` option was present.
     #[structopt(long = "isolate", value_name = "path", parse(from_os_str))]
     pub isolated_roots: Vec<Path>,
+
+    /// Skips locking files before performing an action on them.
+    #[structopt(long)]
+    pub no_lock: bool,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -100,7 +100,11 @@ impl FsCommand {
     /// Obtains a lock to the file if lock == true.
     fn maybe_lock(path: &Path, lock: bool) -> io::Result<Option<FileLock>> {
         if lock {
-            Ok(Some(FileLock::new(path)?))
+            match FileLock::new(path) {
+                Ok(lock) => Ok(Some(lock)),
+                Err(e) if e.kind() == ErrorKind::Unsupported => Ok(None),
+                Err(e) => Err(e),
+            }
         } else {
             Ok(None)
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::{fmt, io};
 
 /// Error reported by top-level fclones functions
 #[derive(Debug)]
@@ -31,4 +31,14 @@ impl From<&str> for Error {
     fn from(s: &str) -> Self {
         Error::new(s.to_owned())
     }
+}
+
+/// Returns error kind.
+/// Maps `libc::EOPNOTSUPP` error to `ErrorKind::Unsupported` on Unix.
+pub fn error_kind(error: &io::Error) -> io::ErrorKind {
+    #[cfg(unix)]
+    if error.raw_os_error() == Some(libc::EOPNOTSUPP) {
+        return io::ErrorKind::Unsupported;
+    }
+    error.kind()
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,3 +1,4 @@
+use crate::error::error_kind;
 use std::fs::File;
 use std::{fs, io};
 
@@ -57,21 +58,21 @@ impl FileLock {
     pub fn new(path: &Path) -> io::Result<FileLock> {
         let path_buf = path.to_path_buf();
         let file = fs::OpenOptions::new()
-            .read(true)
+            .read(false)
             .write(true)
             .create(false)
             .open(&path_buf)
             .map_err(|e| {
                 io::Error::new(
-                    e.kind(),
-                    format!("Failed to open file {}: {}", path.display(), e),
+                    error_kind(&e),
+                    format!("Failed to open file {} for write: {}", path.display(), e),
                 )
             })?;
 
         #[cfg(unix)]
         if let Err(e) = Self::fcntl_lock(&file) {
             return Err(io::Error::new(
-                e.kind(),
+                error_kind(&e),
                 format!("Failed to lock file {}: {}", path.display(), e),
             ));
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ pub fn run_dedupe(op: DedupeOp, config: DedupeConfig, log: &mut Log) -> Result<(
             result.processed_count, upto, result.reclaimed_space
         ));
     } else {
-        let result = run_script(script, log);
+        let result = run_script(script, !dedupe_config.no_lock, log);
         log.info(format!(
             "Processed {} files and reclaimed {}{} space",
             result.processed_count, upto, result.reclaimed_space

--- a/src/reflink.rs
+++ b/src/reflink.rs
@@ -5,15 +5,12 @@ use std::io;
 use filetime::FileTime;
 
 use crate::dedupe::{FsCommand, PathAndMetadata};
-use crate::lock::FileLock;
 use crate::log::Log;
 
 /// Calls OS-specific reflink implementations with an option to call the more generic
 /// one during testing one on Linux ("crosstesting").
 /// The destination file is allowed to exist.
 pub fn reflink(src: &PathAndMetadata, dest: &PathAndMetadata, log: &Log) -> io::Result<()> {
-    let _ = FileLock::new(&dest.path)?; // don't touch a locked file
-
     // Remember the original metadata of the parent directory of the destination file:
     let dest_parent = dest.path.parent();
     let dest_parent_metadata = dest_parent.map(|p| p.to_path_buf().metadata());

--- a/src/reflink.rs
+++ b/src/reflink.rs
@@ -281,7 +281,7 @@ pub mod test {
             };
 
             assert!(
-                cmd.execute(&log)
+                cmd.execute(true, &log)
                     .unwrap_err()
                     .to_string()
                     .starts_with("Failed to deduplicate"),
@@ -328,7 +328,7 @@ pub mod test {
 
             if via_ioctl {
                 assert!(cmd
-                    .execute(&log)
+                    .execute(true, &log)
                     .unwrap_err()
                     .to_string()
                     .starts_with("Failed to deduplicate"));
@@ -338,7 +338,7 @@ pub mod test {
                 assert_eq!(read_file(&file_path_1), "foo");
                 assert_eq!(read_file(&file_path_2), "too large");
             } else {
-                cmd.execute(&log).unwrap();
+                cmd.execute(true, &log).unwrap();
 
                 assert!(file_path_2.exists());
                 assert_eq!(read_file(&file_path_2), "foo");
@@ -378,7 +378,7 @@ pub mod test {
                 target: Arc::new(file_1),
                 link: file_2,
             };
-            cmd.execute(&log).unwrap();
+            cmd.execute(true, &log).unwrap();
 
             assert!(file_path_1.exists());
             assert!(file_path_2.exists());


### PR DESCRIPTION
Use --no-lock to disable locking.
Useful on filesystems that don't support locking at all.

Fixes #121.