### PR TITLE
Don't hash files with same inode identifiers more than once

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -260,6 +260,10 @@ impl FileId {
             device: metadata.dev(),
         }
     }
+
+    pub fn of(f: impl AsRef<FileId>) -> FileId {
+        *f.as_ref()
+    }
 }
 
 /// Convenience wrapper for accessing OS-dependent metadata like inode and device-id


### PR DESCRIPTION
This optimization speeds up processing if the file tree contains
symbolic or hard links. Symbolic and hard links to the same data
will be hashed at most once. The algorithm is also smart enough
to not hash the data at all, if it determines that no other (unlinked)
matches are possible.

Fixes #139.