### PR TITLE
Display path in the warning msg when file metadata can't be accessed

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -290,7 +290,12 @@ pub struct FileMetadata {
 impl FileMetadata {
     pub fn new(path: &Path) -> io::Result<FileMetadata> {
         let path_buf = path.to_path_buf();
-        let metadata = fs::metadata(&path_buf)?;
+        let metadata = fs::metadata(&path_buf).map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("Failed to read metadata of {}: {}", path.display(), e),
+            )
+        })?;
         #[cfg(unix)]
         let id = FileId::from_metadata(&metadata);
         #[cfg(windows)]


### PR DESCRIPTION
Before:
    warn: Permission denied (os error 13)

After:
    warn: Failed to read metadata of /.../file.txt: Permission
    denied (os error 13)

Fixes #147