### PR TITLE
macOS - '/System/Volumes/Data' DiskDevice path remapping

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -248,9 +248,31 @@ impl DiskDevices {
                 String::from_utf8_lossy(d.file_system()).to_string(),
                 pool_sizes,
             );
-            result
-                .mount_points
-                .push((Path::from(d.mount_point()), index));
+
+            // On macOS APFS disk users' data is mounted in '/System/Volumes/Data'
+            // but fused transparently and presented as part of the root filesystem.
+            // It requires remapping Data volume path for this DiskDevice to '/'.
+            // https://www.swiftforensics.com/2019/10/macos-1015-volumes-firmlink-magic.html
+            // https://eclecticlight.co/2020/01/23/catalina-boot-volumes/
+            if cfg!(target_os = "macos") {
+
+                if String::from_utf8_lossy(d.file_system()).to_string() == "apfs" &&
+                   d.mount_point().to_string_lossy() == "/System/Volumes/Data"  {
+                   result
+                       .mount_points
+                       .push((Path::from("/"), index));
+                } else {
+                    result
+                        .mount_points
+                        .push((Path::from(d.mount_point()), index));
+                };
+
+            // For any other OS than macos
+            } else {
+                result
+                    .mount_points
+                    .push((Path::from(d.mount_point()), index));
+            }
         }
         result
             .mount_points


### PR DESCRIPTION
Fixes https://github.com/pkolaczk/fclones/issues/158

On macOS APFS disk all users' data is mounted in '/System/Volumes/Data' but fused transparently using firmlinks and presented as part of the root filesystem. It requires remapping Data volume path for this DiskDevice to '/' in order for fclones correctly recognise device deduplicated files are on.

Ref: 

https://www.swiftforensics.com/2019/10/macos-1015-volumes-firmlink-magic.html

https://eclecticlight.co/2020/01/23/catalina-boot-volumes/