### PR TITLE
Check Rust version in cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [
     ".circleci",
     "release.sh"
 ]
+rust-version = "1.63"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Add required minimum version of Rust (1.63.0) to build master. No way to compile with 1.59, 1.60, 1.61, 1.62, 1.62.1 versions.

The error is:
error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:264:42
    |
264 |             HashFn::Metro => file_hash::<MetroHash128>(chunk, self.buf_len, progress),
    |                                          ^^^^^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:266:41
    |
266 |             HashFn::Xxh3 => file_hash::<Xxh3>(chunk, self.buf_len, progress),
    |                                         ^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:268:43
    |
268 |             HashFn::Blake3 => file_hash::<blake3::Hasher>(chunk, self.buf_len, progress),
    |                                           ^^^^^^^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:270:43
    |
270 |             HashFn::Sha256 => file_hash::<Sha256>(chunk, self.buf_len, progress),
    |                                           ^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:272:43
    |
272 |             HashFn::Sha512 => file_hash::<Sha512>(chunk, self.buf_len, progress),
    |                                           ^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:274:45
    |
274 |             HashFn::Sha3_256 => file_hash::<Sha3_256>(chunk, self.buf_len, progress),
    |                                             ^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:276:45
    |
276 |             HashFn::Sha3_512 => file_hash::<Sha3_512>(chunk, self.buf_len, progress),
    |                                             ^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:332:44
    |
332 |             HashFn::Metro => stream_hash::<MetroHash128>(stream, chunk.len, buf_len, |_| {}),
    |                                            ^^^^^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:334:43
    |
334 |             HashFn::Xxh3 => stream_hash::<Xxh3>(stream, chunk.len, buf_len, |_| {}),
    |                                           ^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:336:45
    |
336 |             HashFn::Blake3 => stream_hash::<blake3::Hasher>(stream, chunk.len, buf_len, |_| {}),
    |                                             ^^^^^^^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:338:45
    |
338 |             HashFn::Sha256 => stream_hash::<Sha256>(stream, chunk.len, buf_len, |_| {}),
    |                                             ^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:340:45
    |
340 |             HashFn::Sha512 => stream_hash::<Sha512>(stream, chunk.len, buf_len, |_| {}),
    |                                             ^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:342:47
    |
342 |             HashFn::Sha3_256 => stream_hash::<Sha3_256>(stream, chunk.len, buf_len, |_| {}),
    |                                               ^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:344:47
    |
344 |             HashFn::Sha3_512 => stream_hash::<Sha3_512>(stream, chunk.len, buf_len, |_| {}),
    |                                               ^^^^^^^^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> src/hasher.rs:628:30
    |
628 |     let hash = stream_hash::<H>(&mut file, chunk.len, buf_len, progress)?.1;
    |                              ^ explicit generic argument not allowed
    |
    = note: see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information

For more information about this error, try `rustc --explain E0632`. error: could not compile `fclones` due to 15 previous errors

Signed-off-by: Andrea Gelmini <andrea.gelmini@gelma.net>