### PR TITLE
Fix panic caused by path prefix on Windows

### DIFF
--- a/src/dedupe.rs
+++ b/src/dedupe.rs
@@ -658,13 +658,11 @@ impl PartitionedFileGroup {
     fn move_target(target_dir: &Arc<Path>, source_path: &Path) -> Path {
         let root = source_path
             .root()
-            .to_string_lossy()
-            .replace(['/', '\\', ':'], "");
+            .map(|p| p.to_string_lossy().replace(['/', '\\', ':'], ""));
         let suffix = source_path.strip_root();
-        if root.is_empty() {
-            target_dir.join(suffix)
-        } else {
-            Arc::new(target_dir.join(Path::from(root))).join(suffix)
+        match root {
+            None => target_dir.join(suffix),
+            Some(root) => Arc::new(target_dir.join(Path::from(root))).join(suffix),
         }
     }
 


### PR DESCRIPTION
Paths on Windows can have a multi-component root.
E.g. C:\ is encoded as two components
'C:' and '\'. Unfortunately Path::root() and
Path::strip_root() didn't account for that properly and stripped only the first component instead of stripping the whole root. That led to incorrect path processing in `fclones move` command and panic.

Fixes #185