### PR TITLE
Obey the open file descriptor limit when grouping files

### DIFF
--- a/src/group.rs
+++ b/src/group.rs
@@ -36,6 +36,7 @@ use crate::log::{Log, LogExt, ProgressBarLength};
 use crate::path::Path;
 use crate::phase::{Phase, Phases};
 use crate::report::{FileStats, ReportHeader, ReportWriter};
+use crate::rlimit::RLIMIT_OPEN_FILES;
 use crate::selector::PathSelector;
 use crate::semaphore::Semaphore;
 use crate::walk::Walk;
@@ -572,6 +573,7 @@ where
                     // when the pool has only one thread.
                     let hash_fn: &HashFn<'static> = unsafe { std::mem::transmute(hash_fn) };
                     thread_pool.spawn_fifo(move || {
+                        let _open_files_guard = RLIMIT_OPEN_FILES.clone().access_owned();
                         let old_hash = fg[0].file_hash.clone();
                         if let Some(hash) = hash_fn((&mut fg[0].file_info, old_hash)) {
                             for mut f in fg {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod pattern;
 mod phase;
 mod reflink;
 mod regex;
+mod rlimit;
 mod selector;
 mod semaphore;
 mod transform;

--- a/src/rlimit.rs
+++ b/src/rlimit.rs
@@ -1,0 +1,68 @@
+// The non-unix cfg does not use all imports
+#![allow(unused_imports)]
+
+use crate::semaphore::Semaphore;
+use lazy_static::lazy_static;
+use std::sync::Arc;
+
+#[cfg(unix)]
+// Get the maximum number of open file descriptors for this process, and if
+// the hard limit is larger than the soft limit increase it.
+fn rlimit_nofile() -> u64 {
+    let mut file_limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    unsafe {
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut file_limit) != 0 {
+            return 200;
+        }
+    }
+
+    if file_limit.rlim_max > file_limit.rlim_cur {
+        let prev = file_limit.rlim_cur;
+        file_limit.rlim_cur = file_limit.rlim_max;
+        unsafe {
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &file_limit) == 0 {
+                file_limit.rlim_max
+            } else {
+                prev
+            }
+        }
+    } else {
+        file_limit.rlim_cur
+    }
+}
+
+#[cfg(unix)]
+// stdin, stdout, stderr, plus two as a buffer
+const OTHER_OPEN_FILES: isize = 3 + 2;
+
+#[cfg(unix)]
+lazy_static! {
+    // Globally track the number of opened files so many parallel operations do not raise
+    // "Too many open files (os error 24)".
+    pub static ref RLIMIT_OPEN_FILES: Arc<Semaphore> = Arc::new(Semaphore::new(std::cmp::max(
+        rlimit_nofile() as isize - OTHER_OPEN_FILES,
+        64 // fallback value
+    )));
+}
+
+#[cfg(not(unix))]
+pub mod not_unix {
+    #[derive(Clone, Copy)]
+    pub struct NoRlimit;
+    impl NoRlimit {
+        pub fn new() -> Self {
+            Self {}
+        }
+        pub fn clone(self) -> Self {
+            self
+        }
+        pub fn access_owned(self) -> () {}
+    }
+}
+#[cfg(not(unix))]
+lazy_static! {
+    pub static ref RLIMIT_OPEN_FILES: not_unix::NoRlimit = not_unix::NoRlimit::new();
+}


### PR DESCRIPTION
Given enough CPU cores and the multiplication factor fclones uses, the number of threads and therefore approximately the maximum number of open files can exceed the usual limit of 1024 on Linux. On macOS this tends to be even lower.

Then some of the "fetch file extents mapping" and "compute hash of file" steps fail with "Too many open files (os error 24)".

To fix this, retrieve the current limit, increase it if possible and stay below it.

Only used on Unix systems.