### PR TITLE
rlimit.rs: fix return type of rlimit_nofile on 32-bit systems

### DIFF
--- a/src/rlimit.rs
+++ b/src/rlimit.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[cfg(unix)]
 // Get the maximum number of open file descriptors for this process, and if
 // the hard limit is larger than the soft limit increase it.
-fn rlimit_nofile() -> u64 {
+fn rlimit_nofile() -> libc::rlim_t {
     let mut file_limit = libc::rlimit {
         rlim_cur: 0,
         rlim_max: 0,


### PR DESCRIPTION
fixes build error for 32-bit targets.