### PR TITLE
Fix max size slider not sticking to Unlimited setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "fclones-gui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "byte-unit",
  "chrono",


### PR DESCRIPTION
When the max size slider was set manually to Unlimited position, it did not update the model properly. So instead of unlimited, the real limit was about 850 GB.

Fixes #209