### PR TITLE
Disable "Find duplicates" button when input paths list is empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "fclones-gui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "byte-unit",
  "chrono",

--- a/fclones-gui/src/input.rs
+++ b/fclones-gui/src/input.rs
@@ -392,6 +392,8 @@ impl InputPageWidgets {
     pub fn update(&self, model: &InputPageModel) {
         self.min_size.set_value(model.min_size.get());
         self.max_size.set_value(model.max_size.get());
+        self.find_duplicates
+            .set_sensitive(model.input_paths.n_items() > 0);
     }
 }
 


### PR DESCRIPTION
Fixes #210