### PR TITLE
Update nix to 0.26.2, bump up fclones to 0.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "fclones"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "assert_matches",
  "atomic-counter",
@@ -582,7 +582,7 @@ dependencies = [
  "libc",
  "maplit",
  "metrohash",
- "nix 0.21.0",
+ "nix",
  "nom",
  "nom-regex",
  "num_cpus",
@@ -611,73 +611,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "fclones"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2001412152306fc5d0f4fea34efdd8c9e21bd0960de95f100af01ba7522a605f"
-dependencies = [
- "atomic-counter",
- "bincode",
- "blake3",
- "byte-unit",
- "byteorder",
- "bytesize",
- "chrono",
- "clap",
- "console",
- "crossbeam-utils",
- "csv",
- "dashmap",
- "dirs",
- "dtparse",
- "dunce",
- "fallible-iterator",
- "fiemap",
- "file-owner",
- "filetime",
- "hex",
- "ignore",
- "indexmap",
- "indicatif",
- "itertools",
- "lazy-init",
- "lazy_static",
- "libc",
- "maplit",
- "metrohash",
- "nix 0.21.0",
- "nom",
- "nom-regex",
- "num_cpus",
- "priority-queue",
- "rand",
- "rayon",
- "reflink",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "sha3",
- "sled",
- "smallvec",
- "stfu8",
- "sysinfo",
- "thread_local",
- "typed-sled",
- "uuid",
- "winapi",
- "winapi-util",
- "xattr",
- "xxhash-rust",
-]
-
-[[package]]
 name = "fclones-gui"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "byte-unit",
  "chrono",
- "fclones 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fclones",
  "itertools",
  "libadwaita",
  "parse-size",
@@ -712,7 +651,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e7c734d6215b191e0c6944437c1b3d60d35ab8ace80ac3fbb0647d8f65cc44"
 dependencies = [
- "nix 0.26.2",
+ "nix",
 ]
 
 [[package]]
@@ -1415,15 +1354,6 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
@@ -1468,19 +1398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "nix"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2633,9 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "ea263437ca03c1522846a4ddafbca2542d0ad5ed9b784909d4b27b76f62bc34a"
 dependencies = [
  "libc",
 ]

--- a/fclones-gui/Cargo.toml
+++ b/fclones-gui/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 byte-unit = "4.0"
 chrono = "0.4"
-fclones = "0.32"
+fclones = { path = "../fclones", version = "0.32.1" }
 itertools = "0.10"
 adw = { package = "libadwaita", version = "0.2", features = ["v1_1"] }
 parse-size = "1"

--- a/fclones/Cargo.toml
+++ b/fclones/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fclones"
-version = "0.32.0"
+version = "0.32.1"
 description = "Finds and removes duplicate files"
 authors = ["Piotr Kołaczkowski <pkolaczk@gmail.com>"]
 homepage = "https://github.com/pkolaczk/fclones"
@@ -73,8 +73,8 @@ fiemap = "0.1"
 [target.'cfg(unix)'.dependencies]
 file-owner = "0.1"
 libc = "0.2"
-nix = "0.21"
-xattr = "0.2"
+nix = "0.26"
+xattr = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/fclones/src/lock.rs
+++ b/fclones/src/lock.rs
@@ -19,8 +19,7 @@ impl FileLock {
     fn nix_as_io_error<T>(result: nix::Result<T>) -> io::Result<T> {
         match result {
             Ok(x) => Ok(x),
-            Err(nix::Error::Sys(errno)) => Err(io::Error::from_raw_os_error(errno as i32)),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e.to_string())),
+            Err(e) => Err(e.into()),
         }
     }
 

--- a/fclones/src/transform.rs
+++ b/fclones/src/transform.rs
@@ -317,9 +317,10 @@ fn create_named_pipe(path: &std::path::Path) -> io::Result<()> {
     use nix::sys::stat;
     use nix::unistd::mkfifo;
     if let Err(e) = mkfifo(path, stat::Mode::S_IRWXU) {
+        let io_err: io::Error = e.into();
         return Err(io::Error::new(
-            io::Error::from(e.as_errno().unwrap()).kind(),
-            format!("Failed to create named pipe {}: {}", path.display(), e),
+            io_err.kind(),
+            format!("Failed to create named pipe {}: {}", path.display(), io_err),
         ));
     }
     Ok(())


### PR DESCRIPTION
Vulnerabilities found in an old version of nix.
Fixes dependabot alerts.