### PR TITLE
Add sorting by status change (ctime) on unix

### DIFF
--- a/fclones/src/config.rs
+++ b/fclones/src/config.rs
@@ -566,42 +566,6 @@ pub enum Priority {
     LeastNested,
 }
 
-impl Priority {
-    pub fn variants() -> Vec<&'static str> {
-        vec![
-            "top",
-            "bottom",
-            "newest",
-            "oldest",
-            "most-recently-modified",
-            "least-recently-modified",
-            "most-recently-accessed",
-            "least-recently-accessed",
-            "most-nested",
-            "least-nested",
-        ]
-    }
-}
-
-impl FromStr for Priority {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "top" => Ok(Priority::Top),
-            "bottom" => Ok(Priority::Bottom),
-            "newest" => Ok(Priority::Newest),
-            "oldest" => Ok(Priority::Oldest),
-            "most-recently-modified" | "mrm" => Ok(Priority::MostRecentlyModified),
-            "least-recently-modified" | "lrm" => Ok(Priority::MostRecentlyModified),
-            "most-recently-accessed" | "mra" => Ok(Priority::MostRecentlyAccessed),
-            "least-recently-accessed" | "lra" => Ok(Priority::LeastRecentlyAccessed),
-            "most-nested" => Ok(Priority::MostNested),
-            "least-nested" => Ok(Priority::LeastNested),
-            _ => Err(format!("Unrecognized priority: {s}")),
-        }
-    }
-}
-
 /// Configures which files should be removed
 #[derive(clap::Args, Debug, Default)]
 #[command(disable_version_flag = true)]

--- a/fclones/src/config.rs
+++ b/fclones/src/config.rs
@@ -560,6 +560,12 @@ pub enum Priority {
     MostRecentlyAccessed,
     /// Give higher priority to the files with the least recent access time.
     LeastRecentlyAccessed,
+    #[cfg(unix)]
+    /// Give higher priority to the files with the most recent status change.
+    MostRecentStatusChange,
+    #[cfg(unix)]
+    /// Give higher priority to the files with the least recent status change.
+    LeastRecentStatusChange,
     /// Give higher priority to the files nested deeper in the directory tree.
     MostNested,
     /// Give higher priority to the files nested shallower in the directory tree.


### PR DESCRIPTION
One use case for ctime is to find, or rather guess, which file was the original after `cp -a` was used. If a snapshot was taken of the filesystem, then keeping data of the one already in the snapshot saves space.

Also removed misleading dead code, this was not detected because the enum is public. I was wondering why `Err(format!("The priority {s} is not supported on Windows"))` would not run!