### PR TITLE
Explicitly specify required features from the nix crate

### DIFF
--- a/fclones/Cargo.toml
+++ b/fclones/Cargo.toml
@@ -73,7 +73,7 @@ fiemap = "0.1"
 [target.'cfg(unix)'.dependencies]
 file-owner = "0.1"
 libc = "0.2"
-nix = "0.26"
+nix = { version = "0.27", features = [ "user", "fs", "ioctl" ] }
 xattr = "1"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Explicitly specify required features from the nix crate: "user", "fs" and "ioctl".

Closes #225