### PR TITLE
New progress bar rendering without indicatif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3c0daaaae24df5995734b689627f8fa02101bc5bbc768be3055b66a010d7af"
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,10 +99,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "atomic-counter"
-version = "1.0.1"
+name = "atty"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f447d68cfa5a9ab0c1c862a703da2a65b5ed1b7ce1153c9eb0169506d56019"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -474,7 +485,6 @@ name = "fclones"
 version = "0.33.0"
 dependencies = [
  "assert_matches",
- "atomic-counter",
  "bincode",
  "blake3",
  "byte-unit",
@@ -496,7 +506,6 @@ dependencies = [
  "hex",
  "ignore",
  "indexmap 2.0.2",
- "indicatif",
  "itertools",
  "lazy-init",
  "lazy_static",
@@ -519,6 +528,7 @@ dependencies = [
  "sha3",
  "sled",
  "smallvec",
+ "status-line",
  "stfu8",
  "sysinfo",
  "tempfile",
@@ -648,6 +658,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -716,19 +735,6 @@ checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.2",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
 ]
 
 [[package]]
@@ -901,15 +907,9 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.3",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -980,12 +980,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -1274,6 +1268,16 @@ name = "smallvec"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
+name = "status-line"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20cc99bbe608305546a850ec4352907279a8b8044f9c13ae58bd0a8ab46ebc1"
+dependencies = [
+ "ansi-escapes",
+ "atty",
+]
 
 [[package]]
 name = "stfu8"

--- a/fclones/Cargo.toml
+++ b/fclones/Cargo.toml
@@ -17,7 +17,6 @@ exclude = [
 rust-version = "1.70"
 
 [dependencies]
-atomic-counter = "1.0"
 bincode = "1.3"
 blake3 = { version = "1.3", optional = true }
 byteorder = "1.4"
@@ -36,7 +35,6 @@ fallible-iterator = "0.3"
 filetime = "0.2"
 hex = "0.4"
 ignore = "0.4.18"
-indicatif = "0.17"
 indexmap = "2"
 itertools = "0.11"
 lazy-init = "0.5"
@@ -56,6 +54,7 @@ sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 sled = "0.34"
 smallvec = "1.8"
+status-line = "0.2.0"
 stfu8 = "0.2"
 sysinfo = "0.29"
 thread_local = "1.1"

--- a/fclones/src/log.rs
+++ b/fclones/src/log.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex, Weak};
 use console::style;
 use nom::lib::std::fmt::Display;
 
-use crate::progress::{FastProgressBar, ProgressTracker};
+use crate::progress::{ProgressBar, ProgressTracker};
 use chrono::Local;
 
 /// Determines the size of the task tracked by ProgressTracker.
@@ -63,7 +63,7 @@ impl<L: Log + ?Sized> LogExt for L {
 /// A logger that uses standard error stream to communicate with the user.
 pub struct StdLog {
     program_name: String,
-    progress_bar: Mutex<Weak<FastProgressBar>>,
+    progress_bar: Mutex<Weak<ProgressBar>>,
     pub log_stderr_to_stdout: bool,
     pub no_progress: bool,
 }
@@ -84,9 +84,9 @@ impl StdLog {
     }
 
     /// Clears any previous progress bar or spinner and installs a new spinner.
-    pub fn spinner(&self, msg: &str) -> Arc<FastProgressBar> {
+    pub fn spinner(&self, msg: &str) -> Arc<ProgressBar> {
         if self.no_progress {
-            return Arc::new(FastProgressBar::new_hidden());
+            return Arc::new(ProgressBar::new_hidden());
         }
         self.progress_bar
             .lock()
@@ -94,30 +94,30 @@ impl StdLog {
             .upgrade()
             .iter()
             .for_each(|pb| pb.finish_and_clear());
-        let result = Arc::new(FastProgressBar::new_spinner(msg));
+        let result = Arc::new(ProgressBar::new_spinner(msg));
         *self.progress_bar.lock().unwrap() = Arc::downgrade(&result);
         result
     }
 
     /// Clears any previous progress bar or spinner and installs a new progress bar.
-    pub fn progress_bar(&self, msg: &str, len: u64) -> Arc<FastProgressBar> {
+    pub fn progress_bar(&self, msg: &str, len: u64) -> Arc<ProgressBar> {
         if self.no_progress {
-            return Arc::new(FastProgressBar::new_hidden());
+            return Arc::new(ProgressBar::new_hidden());
         }
-        let result = Arc::new(FastProgressBar::new_progress_bar(msg, len));
+        let result = Arc::new(ProgressBar::new_progress_bar(msg, len));
         *self.progress_bar.lock().unwrap() = Arc::downgrade(&result);
         result
     }
 
     /// Creates a no-op progressbar that doesn't display itself.
-    pub fn hidden(&self) -> Arc<FastProgressBar> {
-        Arc::new(FastProgressBar::new_hidden())
+    pub fn hidden(&self) -> Arc<ProgressBar> {
+        Arc::new(ProgressBar::new_hidden())
     }
 
     /// Clears any previous progress bar or spinner and installs a new progress bar.
-    pub fn bytes_progress_bar(&self, msg: &str, len: u64) -> Arc<FastProgressBar> {
+    pub fn bytes_progress_bar(&self, msg: &str, len: u64) -> Arc<ProgressBar> {
         if self.no_progress {
-            return Arc::new(FastProgressBar::new_hidden());
+            return Arc::new(ProgressBar::new_hidden());
         }
         self.progress_bar
             .lock()
@@ -125,7 +125,7 @@ impl StdLog {
             .upgrade()
             .iter()
             .for_each(|pb| pb.finish_and_clear());
-        let result = Arc::new(FastProgressBar::new_bytes_progress_bar(msg, len));
+        let result = Arc::new(ProgressBar::new_bytes_progress_bar(msg, len));
         *self.progress_bar.lock().unwrap() = Arc::downgrade(&result);
         result
     }


### PR DESCRIPTION
Replaced indicatif with status-line.
The code got actually shorter and now there are even progress bar tests.

This also opens ability to display more information next to progress bar in the future.

Fixes #217