### PR TITLE
Report cache flusher errors to the caller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +503,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "crossbeam-channel",
  "crossbeam-utils",
  "csv",
  "dashmap",

--- a/fclones/Cargo.toml
+++ b/fclones/Cargo.toml
@@ -25,6 +25,7 @@ byte-unit = "4.0"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std"] }
 clap = { version = "4.4", features = ["derive", "cargo", "wrap_help"] }
 console = "0.15"
+crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 csv = "1.1"
 dashmap = "5.2"

--- a/fclones/src/hasher.rs
+++ b/fclones/src/hasher.rs
@@ -437,6 +437,16 @@ impl FileHasher<'_> {
     }
 }
 
+impl<'a> Drop for FileHasher<'a> {
+    fn drop(&mut self) {
+        if let Some(cache) = self.cache.take() {
+            if let Err(e) = cache.close() {
+                self.log.warn(e);
+            }
+        }
+    }
+}
+
 fn format_output_stream(output: &str) -> String {
     let output = output.trim().to_string();
     if output.is_empty() {


### PR DESCRIPTION
By reporting cache flushing problems to the caller, we can log those errors through Log instead of using eprintln.

Additionally, flush errors at exit are also logged now.