### PR TITLE
Report diagnostic output to stderr

### DIFF
--- a/fclones/src/log.rs
+++ b/fclones/src/log.rs
@@ -134,7 +134,7 @@ impl StdLog {
     /// Does not interfere with progress bar.
     fn eprintln<I: Display>(&self, msg: I) {
         match self.progress_bar.lock().unwrap().upgrade() {
-            Some(pb) if pb.is_visible() => pb.println(format!("{msg}")),
+            Some(pb) if pb.is_visible() => pb.eprintln(format!("{msg}")),
             _ if self.log_stderr_to_stdout => println!("{msg}"),
             _ => eprintln!("{msg}"),
         }

--- a/fclones/src/progress.rs
+++ b/fclones/src/progress.rs
@@ -171,10 +171,10 @@ impl ProgressBar {
         self.status_line.is_visible()
     }
 
-    pub fn println<I: AsRef<str>>(&self, msg: I) {
+    pub fn eprintln<I: AsRef<str>>(&self, msg: I) {
         let was_visible = self.status_line.is_visible();
         self.status_line.set_visible(false);
-        println!("{}", msg.as_ref());
+        eprintln!("{}", msg.as_ref());
         self.status_line.set_visible(was_visible);
     }
 


### PR DESCRIPTION
Fixes a bug accidentally introduced in 0.33
by the progress bar rewrite. Reporting diagnostics to stdout messed up the output.

Fixes #241