### PR TITLE
Downgrade builder image to Debian 10 (buster), remove unneeded pkgs

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,13 +1,11 @@
-FROM rust:1.70-bookworm
+FROM rust:buster
 RUN apt-get update
 RUN apt-get install -y \
     fakeroot \
     alien \
     gcc-mingw-w64-x86-64 \
     gcc-x86-64-linux-gnu \
-    zip \
-    libgtk-4-dev \
-    libadwaita-1-dev
+    zip
 RUN rustup toolchain install stable-x86_64-pc-windows-gnu
 RUN rustup target add x86_64-unknown-linux-gnu
 RUN rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
This allows building packages compatible with older libc.