### PR TITLE
Add shell completion subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb745187d7f4d76267b37485a65e0149edd0e91a4cfcdd3f27524ad86cee9f3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +512,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "clap_complete",
  "console",
  "crossbeam-channel",
  "crossbeam-utils",

--- a/fclones/Cargo.toml
+++ b/fclones/Cargo.toml
@@ -24,6 +24,7 @@ bytesize = "1.1"
 byte-unit = "4.0"
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock", "std"] }
 clap = { version = "4", features = ["derive", "cargo", "wrap_help"] }
+clap_complete = "4"
 console = "0.15"
 crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"

--- a/fclones/README.md
+++ b/fclones/README.md
@@ -163,6 +163,19 @@ are also attached directly to [Releases](https://github.com/pkolaczk/fclones/rel
 
 The build will write the binary to `.cargo/bin/fclones`. 
 
+### Shell completions
+
+`fclones` supports shell completions but you have to set it up manually at the moment,
+which can be done by adding the script printed by the `fclones complete` subcommand to your shell configuration.
+All shells supported by [clap_complete](https://docs.rs/clap_complete/latest/clap_complete/aot/enum.Shell.html) are supported.
+At the time of writing this includes:
+
+- Bash: Add `eval "$(fclones complete bash)"` to your `~/.bashrc`
+- Zsh: Add `source <(fclones complete zsh)` to your `~/.zshrc`
+- Fish: Add `fclones complete fish | source` to your `~/.config/fish/config.fish`
+- Elvish
+- Powershell
+
 ## Usage
 
 `fclones` offers separate commands for finding and removing files. This way, you can inspect

--- a/fclones/src/config.rs
+++ b/fclones/src/config.rs
@@ -729,6 +729,12 @@ pub enum Command {
         #[arg()]
         target: PathBuf,
     },
+
+    /// Print shell completion script to stdout.
+    Complete {
+        /// Shell for which the completion script is generated.
+        shell: clap_complete::Shell,
+    },
 }
 
 impl Command {
@@ -808,5 +814,11 @@ mod test {
         assert_matches!(
             config.command,
             Command::Move { target, .. } if target == PathBuf::from("target"));
+    }
+
+    #[test]
+    fn test_complete_command() {
+        let config: Config = Config::try_parse_from(vec!["fclones", "complete", "zsh"]).unwrap();
+        assert_matches!(config.command, Command::Complete { shell } if shell == clap_complete::Shell::Zsh);
     }
 }


### PR DESCRIPTION
Implements feature request  #164 

I added all shell completions that `clap_complete` supports out of the box. I didn't test them apart from checking that the script generation does not panic. For bash, I also checked that I get some completions but I didn't check if completions for all parameters are there.

This PR could be expanded upon with compile time generation of completions and adding those into the packaging but just having the command should be enough for a first version.