### PR TITLE
Update Arch Linux package link to extra/fclones

### DIFF
--- a/fclones/README.md
+++ b/fclones/README.md
@@ -152,7 +152,7 @@ Installation packages and binaries for some platforms
 are also attached directly to [Releases](https://github.com/pkolaczk/fclones/releases).
 
 ### Third-party Packages
-* [Arch Linux](https://aur.archlinux.org/packages/fclones/) 
+* [Arch Linux](https://aur.archlinux.org/packages/fclones-bin)
 * [Alpine Linux](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/fclones)
 * [NixOS](https://search.nixos.org/packages?channel=unstable&show=fclones&from=0&size=50&sort=relevance&type=packages&query=fclones)
 

--- a/fclones/README.md
+++ b/fclones/README.md
@@ -152,7 +152,7 @@ Installation packages and binaries for some platforms
 are also attached directly to [Releases](https://github.com/pkolaczk/fclones/releases).
 
 ### Third-party Packages
-* [Arch Linux](https://aur.archlinux.org/packages/fclones-bin)
+* [Arch Linux](https://archlinux.org/packages/extra/x86_64/fclones)
 * [Alpine Linux](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/fclones)
 * [NixOS](https://search.nixos.org/packages?channel=unstable&show=fclones&from=0&size=50&sort=relevance&type=packages&query=fclones)
 


### PR DESCRIPTION
Arch Linux package is now at https://aur.archlinux.org/packages/fclones-bin