### PR TITLE
Add --ignore-xattr-errors flag to dedupe

### DIFF
--- a/fclones/src/config.rs
+++ b/fclones/src/config.rs
@@ -653,6 +653,15 @@ pub struct DedupeConfig {
     #[arg(long)]
     pub no_lock: bool,
 
+    /// Ignore errors when getting, setting, or removing extended attributes.
+    ///
+    /// On some systems, certain extended attributes (e.g. com.apple.provenance on macOS)
+    /// cannot be read or set by non-root processes. By default, fclones treats xattr
+    /// failures as hard errors and rolls back the operation. With this flag, permission
+    /// errors on individual xattrs are silently skipped.
+    #[arg(long)]
+    pub ignore_xattr_errors: bool,
+
     /// Allow the size of a file to be different than the size recorded during grouping.
     ///
     /// By default, files are checked for size to prevent accidentally removing a file

--- a/fclones/src/dedupe.rs
+++ b/fclones/src/dedupe.rs
@@ -309,7 +309,12 @@ impl FsCommand {
     }
 
     /// Executes the command and returns the number of bytes reclaimed
-    pub fn execute(&self, should_lock: bool, log: &dyn Log) -> io::Result<FileLen> {
+    pub fn execute(
+        &self,
+        should_lock: bool,
+        ignore_xattr_errors: bool,
+        log: &dyn Log,
+    ) -> io::Result<FileLen> {
         match self {
             FsCommand::Remove { file } => {
                 let _ = Self::maybe_lock(&file.path, should_lock)?;
@@ -328,7 +333,7 @@ impl FsCommand {
             }
             FsCommand::RefLink { target, link } => {
                 let _ = Self::maybe_lock(&link.path, should_lock)?;
-                crate::reflink::reflink(target, link, log)?;
+                crate::reflink::reflink(target, link, ignore_xattr_errors, log)?;
                 Ok(link.metadata.len())
             }
             FsCommand::Move {
@@ -956,14 +961,19 @@ where
 /// On command execution failure, a warning is logged and the execution of remaining commands
 /// continues.
 /// Returns the number of files processed and the amount of disk space reclaimed.
-pub fn run_script<I>(script: I, should_lock: bool, log: &dyn Log) -> DedupeResult
+pub fn run_script<I>(
+    script: I,
+    should_lock: bool,
+    ignore_xattr_errors: bool,
+    log: &dyn Log,
+) -> DedupeResult
 where
     I: IntoParallelIterator<Item = (usize, Vec<FsCommand>)>,
 {
     script
         .into_par_iter()
         .flat_map(|(_, cmd_vec)| cmd_vec)
-        .map(|cmd| cmd.execute(should_lock, log))
+        .map(|cmd| cmd.execute(should_lock, ignore_xattr_errors, log))
         .inspect(|res| {
             if let Err(e) = res {
                 log.warn(e);
@@ -1117,7 +1127,7 @@ mod test {
             create_file(&file_path);
             let file = PathAndMetadata::new(Path::from(&file_path)).unwrap();
             let cmd = FsCommand::Remove { file };
-            cmd.execute(true, &log).unwrap();
+            cmd.execute(true, false, &log).unwrap();
             assert!(!file_path.exists())
         })
     }
@@ -1135,7 +1145,7 @@ mod test {
                 target: target.clone(),
                 use_rename: true,
             };
-            cmd.execute(true, &log).unwrap();
+            cmd.execute(true, false, &log).unwrap();
             assert!(!file_path.exists());
             assert!(target.to_path_buf().exists());
         })
@@ -1154,7 +1164,7 @@ mod test {
                 target: target.clone(),
                 use_rename: false,
             };
-            cmd.execute(true, &log).unwrap();
+            cmd.execute(true, false, &log).unwrap();
             assert!(!file_path.exists());
             assert!(target.to_path_buf().exists());
         })
@@ -1174,7 +1184,7 @@ mod test {
                 target: Path::from(&target),
                 use_rename: false,
             };
-            assert!(cmd.execute(true, &log).is_err());
+            assert!(cmd.execute(true, false, &log).is_err());
         })
     }
 
@@ -1193,7 +1203,7 @@ mod test {
                 target: Arc::new(file_1),
                 link: file_2,
             };
-            cmd.execute(true, &log).unwrap();
+            cmd.execute(true, false, &log).unwrap();
 
             assert!(file_path_1.exists());
             assert!(file_path_2.exists());
@@ -1221,7 +1231,7 @@ mod test {
                 target: Arc::new(file_1),
                 link: file_2,
             };
-            cmd.execute(true, &log).unwrap();
+            cmd.execute(true, false, &log).unwrap();
 
             assert!(file_path_1.exists());
             assert!(file_path_2.exists());
@@ -1502,7 +1512,7 @@ mod test {
                 ..DedupeConfig::default()
             };
             let script = dedupe(vec![group], DedupeOp::Remove, &config, &log);
-            let dedupe_result = run_script(script, !config.no_lock, &log);
+            let dedupe_result = run_script(script, !config.no_lock, false, &log);
             assert_eq!(dedupe_result.processed_count, 2);
             assert!(!root.join("file_1").exists());
             assert!(!root.join("file_2").exists());
@@ -1573,7 +1583,7 @@ mod test {
             let groups = group_files(&group_config, &log).unwrap();
             let dedupe_config = DedupeConfig::default();
             let script = dedupe(groups, DedupeOp::HardLink, &dedupe_config, &log);
-            let dedupe_result = run_script(script, false, &log);
+            let dedupe_result = run_script(script, false, false, &log);
             assert_eq!(dedupe_result.processed_count, 2);
             assert!(file_a1.exists());
             assert!(file_a2.exists());
@@ -1618,7 +1628,7 @@ mod test {
             let groups = group_files(&group_config, &log).unwrap();
             let dedupe_config = DedupeConfig::default();
             let script = dedupe(groups, DedupeOp::Remove, &dedupe_config, &log);
-            let dedupe_result = run_script(script, false, &log);
+            let dedupe_result = run_script(script, false, false, &log);
             assert_eq!(dedupe_result.processed_count, 2);
 
             assert!(file_a1.exists());

--- a/fclones/src/main.rs
+++ b/fclones/src/main.rs
@@ -234,7 +234,12 @@ pub fn run_dedupe(op: DedupeOp, config: DedupeConfig, log: &dyn Log) -> Result<(
             result.processed_count, upto, result.reclaimed_space
         ));
     } else {
-        let result = run_script(script, !dedupe_config.no_lock, log);
+        let result = run_script(
+            script,
+            !dedupe_config.no_lock,
+            dedupe_config.ignore_xattr_errors,
+            log,
+        );
         log.info(format!(
             "Processed {} files and reclaimed {}{} space",
             result.processed_count, upto, result.reclaimed_space

--- a/fclones/src/reflink.rs
+++ b/fclones/src/reflink.rs
@@ -16,7 +16,12 @@ struct XAttr {
 /// Calls OS-specific reflink implementations with an option to call the more generic
 /// one during testing one on Linux ("crosstesting").
 /// The destination file is allowed to exist.
-pub fn reflink(src: &PathAndMetadata, dest: &PathAndMetadata, log: &dyn Log) -> io::Result<()> {
+pub fn reflink(
+    src: &PathAndMetadata,
+    dest: &PathAndMetadata,
+    ignore_xattr_errors: bool,
+    log: &dyn Log,
+) -> io::Result<()> {
     // Remember original metadata of the parent directory:
     let dest_parent = dest.path.parent();
     let dest_parent_metadata = dest_parent.map(|p| p.to_path_buf().metadata());
@@ -30,12 +35,12 @@ pub fn reflink(src: &PathAndMetadata, dest: &PathAndMetadata, log: &dyn Log) -> 
             restore_metadata(&dest_path_buf, &dest.metadata, Restore::TimestampOnly)
         } else {
             #[cfg(unix)]
-            let dest_xattrs = get_xattrs(&dest_path_buf)?;
+            let dest_xattrs = get_xattrs(&dest_path_buf, ignore_xattr_errors)?;
 
             safe_reflink(src, dest, log)?;
 
             #[cfg(unix)]
-            restore_xattrs(&dest_path_buf, dest_xattrs)?;
+            restore_xattrs(&dest_path_buf, dest_xattrs, ignore_xattr_errors)?;
 
             restore_metadata(
                 &dest_path_buf,
@@ -234,71 +239,89 @@ fn restore_metadata(
 }
 
 #[cfg(unix)]
-fn get_xattrs(path: &std::path::Path) -> io::Result<Vec<XAttr>> {
-    use itertools::Itertools;
+fn get_xattrs(path: &std::path::Path, ignore_xattr_errors: bool) -> io::Result<Vec<XAttr>> {
     use xattr::FileExt;
 
     let file = fs::File::open(path)?;
-    file.list_xattr()
-        .map_err(|e| {
-            io::Error::new(
-                e.kind(),
-                format!(
-                    "Failed to list extended attributes of {}: {}",
-                    path.display(),
-                    e
-                ),
-            )
-        })?
-        .map(|name| {
-            Ok(XAttr {
-                value: file.get_xattr(name.as_os_str()).map_err(|e| {
-                    io::Error::new(
-                        e.kind(),
-                        format!(
-                            "Failed to read extended attribute {} of {}: {}",
-                            name.to_string_lossy(),
-                            path.display(),
-                            e
-                        ),
-                    )
-                })?,
-                name,
-            })
-        })
-        .try_collect()
-}
-
-#[cfg(unix)]
-fn restore_xattrs(path: &std::path::Path, xattrs: Vec<XAttr>) -> io::Result<()> {
-    use xattr::FileExt;
-    let file = fs::File::open(path)?;
-    for name in file.list_xattr()? {
-        file.remove_xattr(&name).map_err(|e| {
-            io::Error::new(
-                e.kind(),
-                format!(
-                    "Failed to clear extended attribute {} of {}: {}",
-                    name.to_string_lossy(),
-                    path.display(),
-                    e
-                ),
-            )
-        })?;
-    }
-    for attr in xattrs {
-        if let Some(value) = attr.value {
-            file.set_xattr(&attr.name, &value).map_err(|e| {
-                io::Error::new(
+    let names = file.list_xattr().map_err(|e| {
+        io::Error::new(
+            e.kind(),
+            format!(
+                "Failed to list extended attributes of {}: {}",
+                path.display(),
+                e
+            ),
+        )
+    })?;
+    let mut result = Vec::new();
+    for name in names {
+        match file.get_xattr(name.as_os_str()) {
+            Ok(value) => result.push(XAttr { name, value }),
+            Err(e) if e.kind() == io::ErrorKind::PermissionDenied && ignore_xattr_errors => {
+                continue;
+            }
+            Err(e) => {
+                return Err(io::Error::new(
                     e.kind(),
                     format!(
-                        "Failed to set extended attribute {} of {}: {}",
-                        attr.name.to_string_lossy(),
+                        "Failed to read extended attribute {} of {}: {}",
+                        name.to_string_lossy(),
                         path.display(),
                         e
                     ),
-                )
-            })?;
+                ))
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(unix)]
+fn restore_xattrs(
+    path: &std::path::Path,
+    xattrs: Vec<XAttr>,
+    ignore_xattr_errors: bool,
+) -> io::Result<()> {
+    use xattr::FileExt;
+    let file = fs::File::open(path)?;
+    for name in file.list_xattr()? {
+        match file.remove_xattr(&name) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::PermissionDenied && ignore_xattr_errors => {
+                continue;
+            }
+            Err(e) => {
+                return Err(io::Error::new(
+                    e.kind(),
+                    format!(
+                        "Failed to clear extended attribute {} of {}: {}",
+                        name.to_string_lossy(),
+                        path.display(),
+                        e
+                    ),
+                ))
+            }
+        }
+    }
+    for attr in xattrs {
+        if let Some(value) = attr.value {
+            match file.set_xattr(&attr.name, &value) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::PermissionDenied && ignore_xattr_errors => {
+                    continue;
+                }
+                Err(e) => {
+                    return Err(io::Error::new(
+                        e.kind(),
+                        format!(
+                            "Failed to set extended attribute {} of {}: {}",
+                            attr.name.to_string_lossy(),
+                            path.display(),
+                            e
+                        ),
+                    ))
+                }
+            }
         }
     }
     Ok(())
@@ -424,7 +447,7 @@ pub mod test {
             };
 
             assert!(
-                cmd.execute(true, &log)
+                cmd.execute(true, false, &log)
                     .unwrap_err()
                     .to_string()
                     .starts_with("Failed to deduplicate"),
@@ -471,7 +494,7 @@ pub mod test {
 
             if via_ioctl {
                 assert!(cmd
-                    .execute(true, &log)
+                    .execute(true, false, &log)
                     .unwrap_err()
                     .to_string()
                     .starts_with("Failed to deduplicate"));
@@ -481,7 +504,7 @@ pub mod test {
                 assert_eq!(read_file(&file_path_1), "foo");
                 assert_eq!(read_file(&file_path_2), "too large");
             } else {
-                cmd.execute(true, &log).unwrap();
+                cmd.execute(true, false, &log).unwrap();
 
                 assert!(file_path_2.exists());
                 assert_eq!(read_file(&file_path_2), "foo");
@@ -521,7 +544,7 @@ pub mod test {
                 target: Arc::new(file_1),
                 link: file_2,
             };
-            cmd.execute(true, &log).unwrap();
+            cmd.execute(true, false, &log).unwrap();
 
             assert!(file_path_1.exists());
             assert!(file_path_2.exists());


### PR DESCRIPTION
On macOS, com.apple.provenance is a system-managed xattr that non-root processes cannot set. When dedupe reflinks a file that has this xattr, the restore step fails with EPERM and the operation is rolled back.

This flag makes dedupe silently skip PermissionDenied errors on individual xattr get/set/remove operations, allowing reflink to succeed on files with unrestorable xattrs.

See https://github.com/pkolaczk/fclones/issues/333